### PR TITLE
Provide help text for valid usernames

### DIFF
--- a/approval_frame/templates/registration/registration_form.html
+++ b/approval_frame/templates/registration/registration_form.html
@@ -30,7 +30,12 @@
         {% endfor %}
         <input type='text' class='form-control' id='{{ form.username.id_for_label }}'
                name='{{ form.username.name }}' placeholder='{{ form.username.label }}'
-               value='{{ form.username.value|default_if_none:'' }}' maxlength={{ form.username.field.max_length }}>
+               value='{{ form.username.value|default_if_none:'' }}' maxlength='{{ form.username.field.max_length }}'
+               aria-describedby="username-help-block">
+        <span id='username-help-block'
+              class='help-block'>
+          Username may contain up to 30 letters, numbers, or '.+-_' symbols.
+        </span>
       </div>
       <div class='form-group {% if form.errors.email %} has-error {% endif %}'>
         {% for error in form.errors.email %}


### PR DESCRIPTION
We had some user reports of frustration because they didn't know the requirements for the Username in advance. Added some help text here to aid with that.

Ideally we'd do client-side validation, but that's a bigger project.